### PR TITLE
disabled __attribute__((fallthrough)) for C code

### DIFF
--- a/core/kmod/llring.h
+++ b/core/kmod/llring.h
@@ -97,7 +97,8 @@
 #define _LLRING_H_
 
 #if !defined(__cplusplus) // C
-#define FALLTHROUGH __attribute__((fallthrough))
+// temporary fix for newer gcc compilers to avoid __attribute__((fallthrough)) issues
+#define FALLTHROUGH
 #elif __cplusplus <= 201402L && defined(__clang__) // C++14 or older, Clang
 #define FALLTHROUGH [[clang::fallthrough]]
 #elif __cplusplus <= 201402L && __GNUC__ < 7 // C++14 or older, pre-GCC 7


### PR DESCRIPTION
results in errors when building kmod